### PR TITLE
Opraven odkaz na atom feed v HTML hlavičce

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -36,7 +36,7 @@ author:
 permalink: /:categories/:title/
 markdown: kramdown
 feed:
-  path: atom.xml
+  path: feed.xml
 
 
 # Front Matter Defaults


### PR DESCRIPTION
URL určuje soubor generated/feed.xml a zdá se, že tato varianta je zamýšlená, neboť se vyskytuje i v odkazu v menu.